### PR TITLE
Implement Admin Mode: restrict registration/unregistration to teachers, add login/logout endpoints

### DIFF
--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,6 @@
+{
+  "teachers": [
+    {"username": "teacher1", "password": "password1"},
+    {"username": "teacher2", "password": "password2"}
+  ]
+}


### PR DESCRIPTION
This PR implements Admin Mode as described in issue #5:

- Only teachers (logged in) can register or unregister students for activities
- Teacher credentials are stored in teachers.json
- Added /login and /logout endpoints for teachers
- Students can still view activities and registrations

Closes #5